### PR TITLE
把 FloatView 的 layout param'的  type 为TYPE_TOAST

### DIFF
--- a/src/com/mingle/headsUp/HeadsUpManager.java
+++ b/src/com/mingle/headsUp/HeadsUpManager.java
@@ -108,7 +108,7 @@ public class HeadsUpManager  {
         params.flags = WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
                 | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE|WindowManager.LayoutParams.FLAG_FULLSCREEN
                 | WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN;
-        params.type = WindowManager.LayoutParams.TYPE_SYSTEM_ERROR;
+        params.type = WindowManager.LayoutParams.TYPE_TOAST;
         params.width = WindowManager.LayoutParams.MATCH_PARENT;
         params.height = WindowManager.LayoutParams.WRAP_CONTENT;
         params.format = -3;


### PR DESCRIPTION
这样就可以在任何设备上正常的显示HeadsUp，否则在部分设备上有显示权限限制，一些设备上会阻止悬浮窗的显示。
